### PR TITLE
Fix/4/expose completeness in list table

### DIFF
--- a/digital-garden.php
+++ b/digital-garden.php
@@ -26,6 +26,12 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-bidire
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-block.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-notes-list-table.php';
 
+// Include the helper functions
+$helpers = glob( plugin_dir_path( __FILE__ ) . 'includes/helpers/*.php' );
+foreach ( $helpers as $helper ) {
+	require_once $helper;
+}
+
 // Initialize the custom post type, taxonomy, meta, and other classes
 add_action( 'init', array( 'Digital_Garden_CPT', 'init' ) );
 add_action( 'init', array( 'Digital_Garden_Taxonomy', 'init' ) );

--- a/digital-garden.php
+++ b/digital-garden.php
@@ -24,6 +24,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-fronte
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-settings.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-bidirectional-linking.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-block.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-digital-garden-notes-list-table.php';
 
 // Initialize the custom post type, taxonomy, meta, and other classes
 add_action( 'init', array( 'Digital_Garden_CPT', 'init' ) );

--- a/includes/class-digital-garden-meta.php
+++ b/includes/class-digital-garden-meta.php
@@ -1,4 +1,7 @@
 <?php
+
+use function Digital_Garden\completeness_list;
+
 /**
  * Digital Garden Meta Class
  *
@@ -18,7 +21,7 @@ class Digital_Garden_Meta {
 				'type'         => 'string',
 				'single'       => true,
 				'show_in_rest' => true,
-				'default'      => 'seedling',
+				'default'      => array_key_first( completeness_list() ),
 				'description'  => __( 'Note Completeness', 'digital-garden' ),
 			)
 		);

--- a/includes/class-digital-garden-metabox.php
+++ b/includes/class-digital-garden-metabox.php
@@ -1,4 +1,7 @@
 <?php
+
+use function Digital_Garden\completeness_list;
+
 /**
  * Digital Garden Metabox Class
  *
@@ -44,10 +47,9 @@ class Digital_Garden_Metabox {
 		?>
 		<label for="digital_garden_note_completeness"><?php esc_html_e( 'Completeness:', 'digital-garden' ); ?></label>
 		<select name="digital_garden_note_completeness" id="digital_garden_note_completeness" class="postbox">
-			<option value="seedling" <?php selected( $value, 'seedling' ); ?>><?php esc_html_e( 'Seedling', 'digital-garden' ); ?></option>
-			<option value="sprout" <?php selected( $value, 'sprout' ); ?>><?php esc_html_e( 'Sprout', 'digital-garden' ); ?></option>
-			<option value="sapling" <?php selected( $value, 'sapling' ); ?>><?php esc_html_e( 'Sapling', 'digital-garden' ); ?></option>
-			<option value="evergreen" <?php selected( $value, 'evergreen' ); ?>><?php esc_html_e( 'Evergreen', 'digital-garden' ); ?></option>
+			<?php foreach ( completeness_list() as $completeness_key => $completeness_label ) : ?>
+				<option value="<?php echo esc_attr( $completeness_key ); ?>" <?php selected( $value, $completeness_key ); ?>><?php echo esc_html( $completeness_label ); ?></option>
+			<?php endforeach; ?>
 		</select>
 		<?php
 	}

--- a/includes/class-digital-garden-notes-list-table.php
+++ b/includes/class-digital-garden-notes-list-table.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Digital Garden Notes List Table
+ *
+ * This class handles the addition of a column to the notes list table for the completness meta.
+ */
+
+class Digital_Garden_Notes_List_Table {
+
+	/**
+	 * Initialize the class.
+	 */
+	public static function init() {
+		add_filter( 'manage_note_posts_columns', array( __CLASS__, 'add_completneess_column' ) );
+		add_action( 'manage_note_posts_custom_column', array( __CLASS__, 'render_completeness_column' ), 10, 2 );
+//		add_action( 'admin_menu', array( __CLASS__, 'add_settings_page' ) );
+//		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+	}
+
+	/**
+	 * Add the "Completeness" column to the notes list table.
+	 *
+	 * @param array $columns The existing columns.
+	 * @return array The modified columns.
+	 */
+	public static function add_completneess_column( $columns ) {
+		// Split the array at taxonomy-note_tag to insert our new column after it.
+		$taxonomy_column = array_search( 'taxonomy-note_tag', array_keys( $columns ) );
+		$columns = array_merge(
+
+			array_slice( $columns, 1, $taxonomy_column ),
+			['completeness' => __( 'Completeness', 'digital-garden' )],
+			array_slice( $columns, $taxonomy_column )
+		);
+
+		return $columns;
+	}
+
+	/**
+	 * Render the "Completeness" column in the notes list table.
+	 */
+	public static function render_completeness_column( $column, $post_id ) {
+		$value = get_post_meta( $post_id, '_note_completeness', true );
+
+		switch ( $value ) {
+			case 'seedling':
+				echo '<span style="color: #f1c40f;">&#x1F331;</span> Seedling';
+				break;
+			case 'sprout':
+				echo '<span style="color: #2ecc71;">&#x1F331;</span> Sprout';
+				break;
+			case 'sapling':
+				echo '<span style="color: #3498db;">&#x1F331;</span> Sapling';
+				break;
+			case 'evergreen':
+				echo '<span style="color: #27ae60;">&#x1F332;</span> Evergreen';
+				break;
+		}
+	}
+
+}
+
+// Initialize the class.
+Digital_Garden_Notes_List_Table::init();

--- a/includes/class-digital-garden-notes-list-table.php
+++ b/includes/class-digital-garden-notes-list-table.php
@@ -1,4 +1,7 @@
 <?php
+
+use function Digital_Garden\completeness_list;
+
 /**
  * Digital Garden Notes List Table
  *
@@ -42,19 +45,8 @@ class Digital_Garden_Notes_List_Table {
 	public static function render_completeness_column( $column, $post_id ) {
 		$value = get_post_meta( $post_id, '_note_completeness', true );
 
-		switch ( $value ) {
-			case 'seedling':
-				echo '<span style="color: #f1c40f;">&#x1F331;</span> Seedling';
-				break;
-			case 'sprout':
-				echo '<span style="color: #2ecc71;">&#x1F331;</span> Sprout';
-				break;
-			case 'sapling':
-				echo '<span style="color: #3498db;">&#x1F331;</span> Sapling';
-				break;
-			case 'evergreen':
-				echo '<span style="color: #27ae60;">&#x1F332;</span> Evergreen';
-				break;
+		if ( array_key_exists( $value, completeness_list() ) ) {
+			echo esc_html( completeness_list()[ $value ] );
 		}
 	}
 

--- a/includes/helpers/completeness.php
+++ b/includes/helpers/completeness.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Digital_Garden;
+
+function completeness_list() {
+	$completeness = array(
+		'seedling'  => __( 'Seedling', 'digital-garden' ),
+		'sprout'    => __( 'Sprout', 'digital-garden' ),
+		'sapling'   => __( 'Sapling', 'digital-garden' ),
+		'evergreen' => __( 'Evergreen', 'digital-garden' ),
+	);
+
+	$completeness = apply_filters( 'digital_garden_completeness_list', $completeness );
+
+	return $completeness;
+}

--- a/includes/helpers/completeness.php
+++ b/includes/helpers/completeness.php
@@ -2,6 +2,9 @@
 
 namespace Digital_Garden;
 
+/**
+ * @return array
+ */
 function completeness_list() {
 	$completeness = array(
 		'seedling'  => __( 'Seedling', 'digital-garden' ),
@@ -10,5 +13,10 @@ function completeness_list() {
 		'evergreen' => __( 'Evergreen', 'digital-garden' ),
 	);
 
+	/**
+	 * Filter the list of completeness levels.
+	 *
+	 * The array must be slug => label pairs.
+	 */
 	return apply_filters( 'digital_garden_completeness_list', $completeness );
 }

--- a/includes/helpers/completeness.php
+++ b/includes/helpers/completeness.php
@@ -10,7 +10,5 @@ function completeness_list() {
 		'evergreen' => __( 'Evergreen', 'digital-garden' ),
 	);
 
-	$completeness = apply_filters( 'digital_garden_completeness_list', $completeness );
-
-	return $completeness;
+	return apply_filters( 'digital_garden_completeness_list', $completeness );
 }


### PR DESCRIPTION
This PR adds a new column to the notes list table to include completeness. This closes #4 

In addition, I've added the ability to filter the list of completeness types (if someone doesn't like having 4, or desires a different metaphor) 