### PR TITLE
WIP: Refactor recent notes breadcrumbs to local storage in js 

### DIFF
--- a/assets/js/digital-garden-frontend.js
+++ b/assets/js/digital-garden-frontend.js
@@ -133,4 +133,20 @@ document.addEventListener('DOMContentLoaded', function () {
 		textarea.innerHTML = str;
 		return textarea.value;
 	}
+
+	// Function to add current note to local storage
+	function addCurrentNoteToLocalStorage(note) {
+		let notes = localStorage.getItem('digitalGardenNotes') ? JSON.parse(localStorage.getItem('digitalGardenNotes')) : [];
+
+		// If the notes array already has this note, remove it.
+		if (notes.includes(note)) {
+			notes = notes.filter(item => item !== note);
+			localStorage.setItem('digitalGardenNotes', JSON.stringify(notes));
+		}
+
+		// Add the note to the notes array
+		notes.push(note);
+		localStorage.setItem('digitalGardenNotes', JSON.stringify(notes));
+	}
+
 });

--- a/assets/js/digital-garden-frontend.js
+++ b/assets/js/digital-garden-frontend.js
@@ -5,12 +5,14 @@ document.addEventListener('DOMContentLoaded', function () {
 	const params = new URLSearchParams(window.location.search);
 	let selectedTags = params.get('tags') ? params.get('tags').split(',').map(Number) : [];
 
-	// Add current note to local storage
-	const currentNote = {
-		title: document.querySelectorAll('.wp-block-post-title')[0].textContent,
-		url: window.location.href,
-	};
-	addCurrentNoteToLocalStorage(currentNote);
+	// Check if current page has body class of single-note
+	if (document.body.classList.contains('single-note')) {
+		// Add current note to local storage
+		addCurrentNoteToLocalStorage({
+			title: document.querySelectorAll('.wp-block-post-title')[0].textContent,
+			url: window.location.href,
+		});
+	}
 
 	clearButton.textContent = 'Clear Tags';
 	clearButton.className = 'digital-garden-clear-button';

--- a/assets/js/digital-garden-frontend.js
+++ b/assets/js/digital-garden-frontend.js
@@ -5,6 +5,13 @@ document.addEventListener('DOMContentLoaded', function () {
 	const params = new URLSearchParams(window.location.search);
 	let selectedTags = params.get('tags') ? params.get('tags').split(',').map(Number) : [];
 
+	// Add current note to local storage
+	const currentNote = {
+		title: document.querySelectorAll('.wp-block-post-title')[0].textContent,
+		url: window.location.href,
+	};
+	addCurrentNoteToLocalStorage(currentNote);
+
 	clearButton.textContent = 'Clear Tags';
 	clearButton.className = 'digital-garden-clear-button';
 

--- a/assets/js/digital-garden-frontend.js
+++ b/assets/js/digital-garden-frontend.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', function () {
 		});
 	}
 
+	displayRecentNotes();
+
 	clearButton.textContent = 'Clear Tags';
 	clearButton.className = 'digital-garden-clear-button';
 
@@ -157,7 +159,45 @@ document.addEventListener('DOMContentLoaded', function () {
 
 		// Add the note to the notes array
 		notes.push(note);
+
+		// Limit the number of notes to digitalGardenData.max_steps
+		if (notes.length > digitalGardenData.max_steps) {
+			notes.shift();
+		}
+
 		localStorage.setItem('digitalGardenNotes', JSON.stringify(notes));
+	}
+
+	function displayRecentNotes() {
+		// return if the div is not present.
+		if (!document.querySelector('.digital-garden-breadcrumbs-placeholder')) {
+			return;
+		}
+
+		const notes = localStorage.getItem('digitalGardenNotes') ? JSON.parse(localStorage.getItem('digitalGardenNotes')) : [];
+
+		// Get the div with the class digital-garden-breadcrumbs-placeholder
+		recentNotesContainer = document.querySelector('.digital-garden-breadcrumbs-placeholder');
+
+		// If the div is not found, exit the function
+		if (!recentNotesContainer) {
+			return;
+		}
+
+		// change the class on the div
+		recentNotesContainer.className = 'digital-garden-breadcrumbs';
+
+		let recentNotesContent = '<div class="digital-garden-breadcrumb-title">Recently Viewed Notes</div><ul>';
+
+		if (notes.length > 0) {
+			notes.forEach(note => {
+				recentNotesContent += `<li><a href="${note.url}" class="digital-garden-regular-link">${note.title}</a></li>`;
+			});
+		}
+
+		recentNotesContent += '</ul>';
+
+		recentNotesContainer.innerHTML = recentNotesContent;
 	}
 
 });

--- a/assets/js/digital-garden-frontend.js
+++ b/assets/js/digital-garden-frontend.js
@@ -147,10 +147,12 @@ document.addEventListener('DOMContentLoaded', function () {
 	function addCurrentNoteToLocalStorage(note) {
 		let notes = localStorage.getItem('digitalGardenNotes') ? JSON.parse(localStorage.getItem('digitalGardenNotes')) : [];
 
-		// If the notes array already has this note, remove it.
-		if (notes.includes(note)) {
-			notes = notes.filter(item => item !== note);
-			localStorage.setItem('digitalGardenNotes', JSON.stringify(notes));
+		// Check if the note already exists in the array
+		const existingNoteIndex = notes.findIndex(n => n.title === note.title && n.url === note.url);
+
+		if (existingNoteIndex > -1) {
+			// If the note exists, remove it from the array
+			notes.splice(existingNoteIndex, 1);
 		}
 
 		// Add the note to the notes array

--- a/includes/class-digital-garden-block.php
+++ b/includes/class-digital-garden-block.php
@@ -75,9 +75,10 @@ class Digital_Garden_Block {
 				'digital-garden-frontend',
 				'digitalGardenData',
 				array(
-					'tags'     => self::get_note_tags(),
-					'nonce'    => wp_create_nonce( 'digital_garden_nonce' ),
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'tags'      => self::get_note_tags(),
+					'nonce'     => wp_create_nonce( 'digital_garden_nonce' ),
+					'ajax_url'  => admin_url( 'admin-ajax.php' ),
+					'max_steps' => get_option( 'digital_garden_breadcrumb_steps', 5 ),
 				)
 			);
 

--- a/includes/class-digital-garden-frontend.php
+++ b/includes/class-digital-garden-frontend.php
@@ -14,7 +14,6 @@ class Digital_Garden_Frontend {
 	public static function init() {
 		add_filter( 'the_content', array( __CLASS__, 'convert_hashtags_to_links' ) );
 		add_filter( 'the_content', array( __CLASS__, 'display_timestamps' ) );
-		add_action( 'template_redirect', array( __CLASS__, 'track_recently_viewed' ) );
 		add_filter( 'the_content', array( __CLASS__, 'display_breadcrumbs' ) );
 	}
 
@@ -85,38 +84,6 @@ class Digital_Garden_Frontend {
 	}
 
 	/**
-	 * Track recently viewed notes
-	 */
-	public static function track_recently_viewed() {
-		if ( ! is_singular( 'note' ) ) {
-			return;
-		}
-
-		if ( ! session_id() ) {
-			session_start();
-		}
-
-		$note_id         = get_the_ID();
-		$recently_viewed = isset( $_SESSION['recently_viewed_notes'] ) ? $_SESSION['recently_viewed_notes'] : array();
-		$key             = array_search( $note_id, $recently_viewed, true );
-
-		// Remove the note if it's already in the array.
-		if ( false !== $key ) {
-			unset( $recently_viewed[ $key ] );
-		}
-
-		// Add the note to the beginning of the array.
-		array_unshift( $recently_viewed, $note_id );
-
-		// Limit the number of steps in the breadcrumb trail.
-		$max_steps       = get_option( 'digital_garden_breadcrumb_steps', 5 );
-		$recently_viewed = array_slice( $recently_viewed, 0, $max_steps );
-
-		// Save the updated array back to the session.
-		$_SESSION['recently_viewed_notes'] = $recently_viewed;
-	}
-
-	/**
 	 * Display breadcrumbs in the content.
 	 *
 	 * @param string $content The post content.
@@ -132,29 +99,7 @@ class Digital_Garden_Frontend {
 			return $content;
 		}
 
-		if ( ! session_id() ) {
-			session_start();
-		}
-
-		$recently_viewed = isset( $_SESSION['recently_viewed_notes'] ) ? array_reverse( $_SESSION['recently_viewed_notes'] ) : array();
-
-		if ( ! empty( $recently_viewed ) ) {
-			$breadcrumbs = '<nav class="digital-garden-breadcrumbs"><div class="digital-garden-breadcrumb-title">' . __( 'Recently Viewed Notes', 'digital-garden' ) . '</div><ul>';
-
-			foreach ( $recently_viewed as $note_id ) {
-				if ( get_the_ID() !== $note_id ) {
-					$breadcrumbs .= '<li><a href="' . get_permalink( $note_id ) . '">' . get_the_title( $note_id ) . '</a></li>';
-				} else {
-					$breadcrumbs .= '<li>' . get_the_title( $note_id ) . '</li>';
-				}
-			}
-
-			$breadcrumbs .= '</ul></nav>';
-		}
-
-		$breadcrumbs .= '<nav class="digital-garden-breadcrumbs-placeholder"></nav>';
-
-		return $breadcrumbs . $content;
+		return '<nav class="digital-garden-breadcrumbs-placeholder"></nav>' . $content;
 	}
 }
 

--- a/includes/class-digital-garden-frontend.php
+++ b/includes/class-digital-garden-frontend.php
@@ -152,6 +152,8 @@ class Digital_Garden_Frontend {
 			$breadcrumbs .= '</ul></nav>';
 		}
 
+		$breadcrumbs .= '<nav class="digital-garden-breadcrumbs-placeholder"></nav>';
+
 		return $breadcrumbs . $content;
 	}
 }


### PR DESCRIPTION
closes #1 

This is a proof of concept but headed in the right direction. 
Mostly, I'm looking for feedback on this. It's functionally close but I want to make sure I haven't missed any logic.

A few things I need to finish up:
* The content shift on load can be solved by populating the div with a single empty li to fill the same space.
* I need to capture the note id so I can add the id to the breadcrumb link data so the hover effect works.
* Currently I'm truncating the list at the value of digital_garden_breadcrumb_steps - thinking I might keep like 50/100 and apply the limit on output.