### PR TITLE
Tests!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ build/
 composer.lock
 package-lock.json
 yarn.lock
+vendor
 
 # Optional npm cache directory
 .npm
@@ -92,3 +93,6 @@ yarn.lock
 
 # dotenv environment variables file
 .env
+
+# Test files:
+.phpunit.result.cache

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,64 @@
+# Developer README
+
+## Test Suite Overview
+
+This plugin uses WordPress integration tests via PHPUnit.
+
+Current integration coverage lives in `tests/test-plugin-integration.php` and verifies:
+
+1. Plugin constants are defined (`DIGITAL_GARDEN_VERSION`, URL, and path).
+2. The `note` custom post type is registered and REST-enabled.
+3. The `note_tag` taxonomy is registered for `note` and REST-enabled.
+4. Key blocks are registered (`digital-garden/container`, `digital-garden/note-block`, `digital-garden/search`).
+5. Plugin activation creates the Digital Garden page and stores `digital_garden_page_id`.
+
+## Prerequisites
+
+1. PHP (8.1+ recommended).
+2. Composer.
+3. MySQL/MariaDB running locally.
+4. `svn` (used by the WP test installer script).
+
+## First-Time Setup
+
+Run from the plugin root:
+
+```bash
+composer install
+```
+
+Install WordPress test libraries and create a dedicated test DB:
+
+```bash
+bash bin/install-wp-tests.sh dg_tests <db-user> <db-pass> 127.0.0.1 latest
+```
+
+Notes:
+
+1. `dg_tests` is a disposable database for tests only.
+2. The script downloads WordPress test files into your system temp directory.
+
+## Run Tests
+
+Run the full integration suite:
+
+```bash
+./vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+Alternative:
+
+```bash
+composer test
+```
+
+## Troubleshooting
+
+1. `Could not find .../wordpress-tests-lib/includes/functions.php`
+Run the installer script again (`bin/install-wp-tests.sh`).
+
+2. `Error establishing a database connection`
+Verify DB user/password/host and ensure MySQL is running.
+
+3. `The PHPUnit Polyfills library is a requirement`
+Run `composer install` to install dev dependencies.

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		rm -rf $TMPDIR/wordpress-trunk/*
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		create_db
+	fi
+}
+
+install_wp
+install_test_suite
+install_db

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "wolfpaw/digital-garden",
+  "name": "fixupfox/digital-garden",
   "description": "Digital Garden WordPress plugin",
   "type": "wordpress-plugin",
   "require": {},

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "wolfpaw/digital-garden",
+  "description": "Digital Garden WordPress plugin",
+  "type": "wordpress-plugin",
+  "require": {},
+  "require-dev": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^4.0"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml.dist"
+  },
+  "config": {
+    "sort-packages": true
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<env name="WP_TESTS_PHPUNIT_POLYFILLS_PATH" value="./vendor/yoast/phpunit-polyfills"/>
+	</php>
+	<testsuites>
+		<testsuite name="testing">
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+			<exclude>./tests/test-sample.php</exclude>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package Digital_Garden
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/digital-garden.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";

--- a/tests/test-plugin-integration.php
+++ b/tests/test-plugin-integration.php
@@ -4,6 +4,17 @@
  */
 class Digital_Garden_Integration_Test extends WP_UnitTestCase {
 
+	public function tear_down() {
+		$page_id = (int) get_option( 'digital_garden_page_id' );
+		if ( $page_id > 0 && get_post( $page_id ) ) {
+			wp_delete_post( $page_id, true );
+		}
+
+		delete_option( 'digital_garden_page_id' );
+
+		parent::tear_down();
+	}
+
 	public function test_plugin_constants_are_defined() {
 		$this->assertTrue( defined( 'DIGITAL_GARDEN_VERSION' ) );
 		$this->assertTrue( defined( 'DIGITAL_GARDEN_PLUGIN_URL' ) );

--- a/tests/test-plugin-integration.php
+++ b/tests/test-plugin-integration.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Integration tests for plugin bootstrap and WordPress registrations.
+ */
+class Digital_Garden_Integration_Test extends WP_UnitTestCase {
+
+	public function test_plugin_constants_are_defined() {
+		$this->assertTrue( defined( 'DIGITAL_GARDEN_VERSION' ) );
+		$this->assertTrue( defined( 'DIGITAL_GARDEN_PLUGIN_URL' ) );
+		$this->assertTrue( defined( 'DIGITAL_GARDEN_PLUGIN_PATH' ) );
+	}
+
+	public function test_note_post_type_is_registered() {
+		$this->assertTrue( post_type_exists( 'note' ) );
+
+		$post_type = get_post_type_object( 'note' );
+		$this->assertNotNull( $post_type );
+		$this->assertTrue( $post_type->public );
+		$this->assertTrue( $post_type->show_in_rest );
+	}
+
+	public function test_note_tag_taxonomy_is_registered_for_note() {
+		$this->assertTrue( taxonomy_exists( 'note_tag' ) );
+
+		$taxonomy = get_taxonomy( 'note_tag' );
+		$this->assertNotNull( $taxonomy );
+		$this->assertContains( 'note', $taxonomy->object_type );
+		$this->assertTrue( $taxonomy->show_in_rest );
+	}
+
+	public function test_core_digital_garden_blocks_are_registered() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		$this->assertTrue( $registry->is_registered( 'digital-garden/container' ) );
+		$this->assertTrue( $registry->is_registered( 'digital-garden/note-block' ) );
+		$this->assertTrue( $registry->is_registered( 'digital-garden/search' ) );
+	}
+
+	public function test_activation_creates_digital_garden_page() {
+		delete_option( 'digital_garden_page_id' );
+
+		digital_garden_activate();
+
+		$page_id = (int) get_option( 'digital_garden_page_id' );
+		$this->assertGreaterThan( 0, $page_id );
+
+		$page = get_post( $page_id );
+		$this->assertNotNull( $page );
+		$this->assertSame( 'page', $page->post_type );
+		$this->assertSame( 'garden', $page->post_name );
+		$this->assertStringContainsString( 'digital-garden/container', $page->post_content );
+	}
+}

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class SampleTest
+ *
+ * @package Digital_Garden
+ */
+
+/**
+ * Sample test case.
+ */
+class SampleTest extends WP_UnitTestCase {
+
+	/**
+	 * A single example test.
+	 */
+	public function test_sample() {
+		// Replace this with some actual testing code.
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
This adds automated tests to run locally (finally)! It includes all config necessary and is built on top of the generated code from `wp scaffold plugin-tests Digital-Garden`. This will close #10 and then I'll add a task to run the tests as a github action.

**README-DEV.md**
This has instructions to install and run tests with some basic troubleshooting.

**Test infrastructure**
`composer.json` with PHPUnit and Yoast PHPUnit Polyfills as development dependencies and a `test` script for running tests.
`phpunit.xml.dist` to configure PHPUnit, define test suites, and set environment variables for polyfills.
`tests/bootstrap.php` to bootstrap the WordPress testing environment.

**Tests**
A generated sample test file `tests/test-sample.php`.
`tests/test-plugin-integration.php` containing tests to verify plugin constants, custom post type and taxonomy registration, block registration, and plugin activation logic.